### PR TITLE
Log file elimination & MCP tab implementation

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -19,7 +19,7 @@ type BootstrapConfig struct {
 	Version         string // Binary version, used to detect and replace stale daemons
 	AppName         string // e.g. "tinywasm" — used in HTTP server version endpoint
 	APIKeyPath      string // path to persist API key; empty = no auth (open mode)
-	Logger          func(messages ...any)
+	Logger          any    // can be func(...any) or *Logger
 	DB              DB
 	GitHandler      devflow.GitClient
 	GoModHandler    devflow.GoModInterface
@@ -32,6 +32,16 @@ type BootstrapConfig struct {
 
 // Bootstrap is the main entry point for the application logic
 func Bootstrap(cfg BootstrapConfig) {
+	var loggerFunc func(messages ...any)
+	if l, ok := cfg.Logger.(func(...any)); ok {
+		loggerFunc = l
+	} else if l, ok := cfg.Logger.(*Logger); ok {
+		loggerFunc = l.Logger
+	}
+	if loggerFunc == nil {
+		loggerFunc = func(messages ...any) {}
+	}
+
 	// 1. Check if we should run as Daemon (headless) or Client (TUI)
 
 	if cfg.McpMode {
@@ -48,7 +58,7 @@ func Bootstrap(cfg BootstrapConfig) {
 			killDaemon()
 			waitForPortFree("3030")
 
-			if err := startDaemonProcess(cfg.StartDir, cfg.Logger); err != nil {
+			if err := startDaemonProcess(cfg.StartDir, loggerFunc); err != nil {
 				fmt.Printf("Failed to restart daemon: %v\n", err)
 				os.Exit(1)
 			}
@@ -57,7 +67,7 @@ func Bootstrap(cfg BootstrapConfig) {
 		runClient(cfg)
 	} else {
 		// Port free -> Start Daemon in background, then run Client
-		if err := startDaemonProcess(cfg.StartDir, cfg.Logger); err != nil {
+		if err := startDaemonProcess(cfg.StartDir, loggerFunc); err != nil {
 			fmt.Printf("Failed to start daemon: %v\n", err)
 			os.Exit(1)
 		}
@@ -67,6 +77,16 @@ func Bootstrap(cfg BootstrapConfig) {
 }
 
 func runClient(cfg BootstrapConfig) {
+	var loggerFunc func(messages ...any)
+	if l, ok := cfg.Logger.(func(...any)); ok {
+		loggerFunc = l
+	} else if l, ok := cfg.Logger.(*Logger); ok {
+		loggerFunc = l.Logger
+	}
+	if loggerFunc == nil {
+		loggerFunc = func(messages ...any) {}
+	}
+
 	// Client mode
 	// Use real TUI with SSE client enabled to receive logs from the daemon
 	exitChan := make(chan bool)
@@ -88,11 +108,11 @@ func runClient(cfg BootstrapConfig) {
 	if cfg.StartDir != "" {
 		body, err := json.Marshal(map[string]string{"key": "start", "value": cfg.StartDir})
 		if err != nil {
-			cfg.Logger("Error marshaling action body:", err)
+			loggerFunc("Error marshaling action body:", err)
 		} else {
 			req, err := http.NewRequest("POST", baseURL+"/tinywasm/action", bytes.NewReader(body))
 			if err != nil {
-				cfg.Logger("Error creating request:", err)
+				loggerFunc("Error creating request:", err)
 			} else {
 				req.Header.Set("Content-Type", "application/json")
 				if apiKey != "" {
@@ -100,7 +120,7 @@ func runClient(cfg BootstrapConfig) {
 				}
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
-					cfg.Logger("Error sending start action to daemon:", err)
+					loggerFunc("Error sending start action to daemon:", err)
 				} else {
 					resp.Body.Close()
 				}

--- a/cmd/tinywasm/main.go
+++ b/cmd/tinywasm/main.go
@@ -37,7 +37,8 @@ func main() {
 	// Initialize Git Handler
 	gitHandler, err := devflow.NewGit()
 	if err != nil {
-		logger.Logger("Error initializing Git handler:", err)
+		log.Println("Error initializing Git handler:", err)
+		logger.InternalError("Error initializing Git handler:", err)
 	}
 
 	if projectRoot, err := devflow.FindProjectRoot(startDir); err == nil {
@@ -49,13 +50,15 @@ func main() {
 		goModHandler.SetRootDir(startDir)
 		logger.SetRootDir(startDir)
 	}
+	logger.SetDebug(*debugFlag)
 
 	goModHandler.SetLog(logger.Logger)
 
 	// Initialize DB
 	db, err := kvdb.New(filepath.Join(startDir, ".env"), logger.Logger, &app.FileStore{})
 	if err != nil {
-		logger.Logger("Failed to initialize database:", err)
+		log.Println("Failed to initialize database:", err)
+		logger.InternalError("Failed to initialize database:", err)
 		return
 	}
 
@@ -65,7 +68,7 @@ func main() {
         McpMode: *mcpFlag,
         Debug: *debugFlag,
         Version: Version,
-        Logger: logger.Logger,
+        Logger: logger,
         DB: db,
         GitHandler: gitHandler,
         GoModHandler: goModHandler,
@@ -75,7 +78,6 @@ func main() {
             return devtui.NewTUI(&devtui.TuiConfig{
 				AppName:    "TINYWASM",
 				AppVersion: Version,
-				ExitChan:   exitChan,
 				Color:      devtui.DefaultPalette(),
 				Logger:     func(messages ...any) { logger.Logger(messages...) },
 				Debug:      *debugFlag,

--- a/daemon.go
+++ b/daemon.go
@@ -18,7 +18,13 @@ import (
 
 // runDaemon starts the global MCP daemon on port 3030
 func runDaemon(cfg BootstrapConfig) {
-	logger := cfg.Logger
+	var logger func(messages ...any)
+	if l, ok := cfg.Logger.(func(...any)); ok {
+		logger = l
+	} else if l, ok := cfg.Logger.(*Logger); ok {
+		logger = l.Logger
+	}
+
 	if logger == nil {
 		logger = func(messages ...any) {}
 	}
@@ -74,7 +80,7 @@ func runDaemon(cfg BootstrapConfig) {
 	proxy := NewProjectToolProxy()
 
 	// Define the daemon tool provider that controls the project lifecycles
-	dtp := newDaemonToolProvider(cfg, logger)
+	dtp := NewDaemonToolProvider(cfg, logger)
 
 	toolProviders := append(cfg.McpToolHandlers, dtp, proxy)
 	mcpServer, err := mcp.NewServer(mcpConfig, toolProviders)
@@ -89,6 +95,13 @@ func runDaemon(cfg BootstrapConfig) {
 	}
 
 	ssePub := NewSSEPublisher(sseServer)
+
+	// Wire Logger redirection to SSE
+	if l, ok := cfg.Logger.(*Logger); ok {
+		l.Redir = func(messages ...any) {
+			ssePub.PublishLog(l.sprint(messages...))
+		}
+	}
 
 	// Update dtp to store proxy, mcpServer and ssePub
 	dtp.toolProxy = proxy
@@ -327,11 +340,23 @@ type daemonToolProvider struct {
 	lastPath      string // Keep track of the last path for remote restarts
 }
 
-func newDaemonToolProvider(cfg BootstrapConfig, logger func(messages ...any)) *daemonToolProvider {
+func NewDaemonToolProvider(cfg BootstrapConfig, logger func(messages ...any)) *daemonToolProvider {
 	return &daemonToolProvider{
 		cfg:    cfg,
 		logger: logger,
 	}
+}
+
+func (d *daemonToolProvider) SetSSEPub(ssePub *SSEPublisher) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.ssePub = ssePub
+}
+
+func (d *daemonToolProvider) SetLastPath(path string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lastPath = path
 }
 
 func (d *daemonToolProvider) Tools() []mcp.Tool {
@@ -369,7 +394,7 @@ func (d *daemonToolProvider) Tools() []mcp.Tool {
 			InputSchema: `{"type":"object","properties":{"lines":{"type":"integer","description":"Number of log lines to return (default 50)"}}}`,
 			Resource:    "logs",
 			Action:      'r',
-			Execute:     d.executeGetLogs,
+			Execute:     d.ExecuteGetLogs,
 		},
 		{
 			Name:        "browser_screenshot",
@@ -430,8 +455,8 @@ func (d *daemonToolProvider) Tools() []mcp.Tool {
 	}
 }
 
-// executeGetLogs reads the latest log lines from the active project's logs.log file.
-func (d *daemonToolProvider) executeGetLogs(ctx *context.Context, req mcp.Request) (*mcp.Result, error) {
+// ExecuteGetLogs reads the latest log lines from the active project from the SSE ring buffer.
+func (d *daemonToolProvider) ExecuteGetLogs(ctx *context.Context, req mcp.Request) (*mcp.Result, error) {
 	d.mu.Lock()
 	path := d.lastPath
 	d.mu.Unlock()
@@ -440,14 +465,27 @@ func (d *daemonToolProvider) executeGetLogs(ctx *context.Context, req mcp.Reques
 		return mcp.Text("No active project. Call start_development first."), nil
 	}
 
-	logPath := path + "/logs.log"
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		return mcp.Text("Log file not found or not yet created."), nil
+	if d.ssePub == nil {
+		return mcp.Text("Log system not initialized."), nil
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	lines := d.ssePub.RecentLogs()
+	if len(lines) == 0 {
+		return mcp.Text("No logs available yet."), nil
+	}
+
 	limit := 50
+	// Allow overriding limit from params
+	argsBytes := []byte(req.Params.Arguments)
+	if limitVal := string(mcp.ExtractJSONValue(argsBytes, "lines")); limitVal != "" {
+		// Quick parse if it's a simple number
+		var l int
+		fmt.Sscanf(limitVal, "%d", &l)
+		if l > 0 {
+			limit = l
+		}
+	}
+
 	if len(lines) > limit {
 		lines = lines[len(lines)-limit:]
 	}

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -5,7 +5,7 @@
 | Stage | File | Status | Dependency |
 |-------|------|--------|------------|
 | 1 | [PLAN_stage1_webclient.md](PLAN_stage1_webclient.md) | pending | tinywasm/client Stage 3 |
-| 2 | [PLAN_stage2_logs.md](PLAN_stage2_logs.md) | pending | none |
+| 2 | [PLAN_stage2_logs.md](PLAN_stage2_logs.md) | completed | none |
 | 3 | [PLAN_stage3_env.md](PLAN_stage3_env.md) | pending | Stage 2, tinywasm/fmt PLAN |
 | 4 | [PLAN_stage4_shutdown.md](PLAN_stage4_shutdown.md) | pending | Stage 2, devtui PLAN_clean_shutdown |
 

--- a/handler.go
+++ b/handler.go
@@ -46,6 +46,7 @@ type Handler struct {
 	startOnce        sync.Once
 	SectionBuild     any // Store reference to build tab
 	SectionDeploy    any // Store reference to deploy tab
+	SectionMCP       any // Store reference to mcp tab
 	RestartRequested bool
 
 	// MCP Server for LLM integration (owns /mcp, /logs, /action, /state, /version routes)

--- a/logs.go
+++ b/logs.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	twfmt "github.com/tinywasm/fmt"
 	"os"
 	"time"
 )
@@ -9,7 +10,9 @@ import (
 // Logger handles logging operations
 type Logger struct {
 	RootDir     string
+	debug       bool
 	initialized bool
+	Redir       func(messages ...any)
 }
 
 // NewLogger creates a new Logger instance
@@ -23,10 +26,38 @@ func (l *Logger) SetRootDir(path string) {
 	l.initialized = true
 }
 
-// Logger writes messages to a log file only if initialized
+// SetDebug enables or disables debug mode
+func (l *Logger) SetDebug(v bool) {
+	l.debug = v
+}
+
+// Logger sends messages through the normal channel (TUI/SSE). Never writes to file.
 func (l *Logger) Logger(messages ...any) {
 	// Don't write logs if project not initialized
 	if !l.initialized {
+		return
+	}
+	// Normal logs flow exclusively through TUI/SSE.
+	if l.Redir != nil {
+		l.Redir(messages...)
+	}
+}
+
+func (l *Logger) sprint(messages ...any) string {
+	res := ""
+	for i, m := range messages {
+		if i > 0 {
+			res += " "
+		}
+		res += twfmt.Sprint(m)
+	}
+	return res
+}
+
+// InternalError writes to logs.log only when debug mode is active.
+// Use only for errors internal to tinywasm itself, not for project build errors.
+func (l *Logger) InternalError(messages ...any) {
+	if !l.initialized || !l.debug {
 		return
 	}
 
@@ -39,6 +70,6 @@ func (l *Logger) Logger(messages ...any) {
 	if err == nil {
 		defer logFile.Close()
 		timestamp := time.Now().Format("2006-01-02 15:04:05")
-		logFile.WriteString(fmt.Sprintf("[%s] %v\n", timestamp, fmt.Sprint(messages...)))
+		logFile.WriteString(fmt.Sprintf("[%s] %v\n", timestamp, l.sprint(messages...)))
 	}
 }

--- a/section-mcp.go
+++ b/section-mcp.go
@@ -1,0 +1,8 @@
+package app
+
+// AddSectionMCP creates the MCP tab in the TUI
+func (h *Handler) AddSectionMCP() any {
+	section := h.Tui.NewTabSection("MCP", "MCP Daemon Status")
+	h.SectionMCP = section
+	return section
+}

--- a/sse_publisher.go
+++ b/sse_publisher.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -24,11 +25,45 @@ type LogEntry struct {
 }
 
 // SSEPublisher wraps an ssePublisher hub with tinywasm-specific publishing logic.
-type SSEPublisher struct{ hub ssePublisher }
+type SSEPublisher struct {
+	hub   ssePublisher
+	mu    sync.Mutex
+	ring  [100]string
+	head  int
+	count int
+}
 
 func NewSSEPublisher(hub ssePublisher) *SSEPublisher { return &SSEPublisher{hub: hub} }
 
+func (p *SSEPublisher) addToRing(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ring[p.head] = msg
+	p.head = (p.head + 1) % 100
+	if p.count < 100 {
+		p.count++
+	}
+}
+
+// RecentLogs returns up to 100 of the latest log entries in chronological order.
+func (p *SSEPublisher) RecentLogs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	res := make([]string, 0, p.count)
+	if p.count < 100 {
+		for i := 0; i < p.count; i++ {
+			res = append(res, p.ring[i])
+		}
+	} else {
+		for i := 0; i < 100; i++ {
+			res = append(res, p.ring[(p.head+i)%100])
+		}
+	}
+	return res
+}
+
 func (p *SSEPublisher) PublishTabLog(tabTitle, handlerName, handlerColor, msg string) {
+	p.addToRing(msg)
 	if p.hub == nil {
 		return
 	}

--- a/start.go
+++ b/start.go
@@ -21,7 +21,14 @@ var TestMode bool
 // CRITICAL: UI, Browser and DB instances created in main.go, passed here as interfaces
 // mcpToolHandlers: optional external Handlers that implement Tools() for MCP tool discovery
 // onProjectReady: optional callback called after handler initialization (for daemon mode to set up proxy)
-func Start(startDir string, logger func(messages ...any), ui TuiInterface, browser BrowserInterface, db DB, ExitChan chan bool, serverFactory ServerFactory, githubAuth any, gitHandler devflow.GitClient, goModHandler devflow.GoModInterface, headless bool, clientMode bool, onProjectReady func(*Handler), mcpToolHandlers ...mcp.ToolProvider) bool {
+func Start(startDir string, logger any, ui TuiInterface, browser BrowserInterface, db DB, ExitChan chan bool, serverFactory ServerFactory, githubAuth any, gitHandler devflow.GitClient, goModHandler devflow.GoModInterface, headless bool, clientMode bool, onProjectReady func(*Handler), mcpToolHandlers ...mcp.ToolProvider) bool {
+
+	var loggerFunc func(messages ...any)
+	if l, ok := logger.(func(...any)); ok {
+		loggerFunc = l
+	} else if l, ok := logger.(*Logger); ok {
+		loggerFunc = l.Logger
+	}
 
 	// Initialize Go Handler
 	GoHandler, _ := devflow.NewGo(gitHandler)
@@ -32,7 +39,7 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 		RootDir:       startDir,
 		Tui:           ui, // UI passed from main.go
 		ExitChan:      ExitChan,
-		Logger:        logger,
+		Logger:        loggerFunc,
 
 		DB:            db,
 		serverFactory: serverFactory,
@@ -44,7 +51,7 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 	}
 
 	// Noop initial logger to avoid nil check issues
-	h.Logger = logger
+	h.Logger = loggerFunc
 
 	// Check if we are in dev mode
 	h.CheckDevMode()
@@ -57,7 +64,7 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 	// Validate directory
 	homeDir, _ := os.UserHomeDir()
 	if startDir == homeDir || startDir == "/" {
-		logger("Cannot run tinywasm in user root directory. Please run in a Go project directory")
+		loggerFunc("Cannot run tinywasm in user root directory. Please run in a Go project directory")
 		return false
 	}
 
@@ -68,6 +75,7 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 	// CRITICAL: Initialize sections BEFORE starting lifecycle
 	h.SectionBuild = h.AddSectionBUILD()
 	h.AddSectionDEPLOY()
+	h.SectionMCP = h.AddSectionMCP()
 
 	// Register GitHubAuth in TUI FIRST (so it gets the TUI logger)
 	// This must happen BEFORE starting the auth Future
@@ -90,15 +98,15 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 	githubFuture := devflow.NewFuture(func() (any, error) {
 		if githubAuth != nil {
 			if auth, ok := githubAuth.(devflow.GitHubAuthenticator); ok {
-				return devflow.NewGitHub(logger, auth)
+				return devflow.NewGitHub(loggerFunc, auth)
 			}
 		}
-		return devflow.NewGitHub(logger)
+		return devflow.NewGitHub(loggerFunc)
 	})
 
 	// Initialize GoNew orchestrator with the future
 	GoNew := devflow.NewGoNew(gitHandler, githubFuture, GoHandler)
-	GoNew.SetLog(logger)
+	GoNew.SetLog(loggerFunc)
 	h.GoNew = GoNew
 	// Prevents goroutine leak: drain future when app exits so the
 	// internal goroutine can proceed to close(f.done) and exit.
@@ -147,9 +155,22 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 		})
 
 		ssePub := NewSSEPublisher(sseServer)
+
+		// Wire Logger redirection to SSE
+		if l, ok := logger.(*Logger); ok {
+			l.Redir = func(messages ...any) {
+				ssePub.PublishLog(l.sprint(messages...))
+			}
+		}
+
 		h.Logger = func(messages ...any) {
-			logger(messages...)
-			ssePub.PublishLog(fmt.Sprint(messages...))
+			loggerFunc(messages...)
+			if l, ok := logger.(*Logger); ok {
+				ssePub.PublishLog(l.sprint(messages...))
+			} else {
+				// Fallback if not using our Logger struct
+				ssePub.PublishLog(fmt.Sprint(messages...))
+			}
 		}
 
 		appVersion := "1.0.0"
@@ -172,16 +193,16 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 		var err error
 		h.MCP, err = mcp.NewServer(mcpConfig, toolHandlers)
 		if err != nil {
-			logger("Failed to initialize MCP Server:", err)
+			loggerFunc("Failed to initialize MCP Server:", err)
 			return false
 		}
 
 		// Configure IDEs (standalone mode)
 		if err := ConfigureIDEs("tinywasm", appVersion, mcpPort, ""); err != nil {
-			logger("Warning: Failed to configure IDEs:", err)
+			loggerFunc("Warning: Failed to configure IDEs:", err)
 		}
 
-		h.Tui.AddHandler(h.MCP, colorOrangeLight, h.SectionBuild)
+		h.Tui.AddHandler(h.MCP, colorOrangeLight, h.SectionMCP)
 		SetActiveHandler(h)
 
 		mux := http.NewServeMux()
@@ -217,9 +238,9 @@ func Start(startDir string, logger func(messages ...any), ui TuiInterface, brows
 				<-ExitChan
 				server.Close()
 			}()
-			logger("Standalone listener on", server.Addr)
+			loggerFunc("Standalone listener on", server.Addr)
 			if err := server.ListenAndServe(); err != http.ErrServerClosed {
-				logger("Standalone server error:", err)
+				loggerFunc("Standalone server error:", err)
 			}
 		}()
 

--- a/test/daemon_logs_test.go
+++ b/test/daemon_logs_test.go
@@ -1,0 +1,65 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tinywasm/app"
+	"github.com/tinywasm/context"
+	"github.com/tinywasm/mcp"
+	twjson "github.com/tinywasm/json"
+)
+
+func TestDaemonGetLogsFromRing(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "daemon_logs_test")
+	defer os.RemoveAll(tmpDir)
+
+	cfg := app.BootstrapConfig{
+		Version: "1.0.0",
+		Logger:  func(m ...any) {},
+	}
+
+	dtp := app.NewDaemonToolProvider(cfg, func(m ...any) {})
+	ssePub := app.NewSSEPublisher(nil)
+	dtp.SetSSEPub(ssePub)
+	dtp.SetLastPath(tmpDir)
+
+	// Add some logs to the ring buffer
+	for i := 1; i <= 5; i++ {
+		ssePub.PublishTabLog("TAB", "HAND", "COL", fmt.Sprintf("Log line %d", i))
+	}
+
+	ctx := context.Background()
+	req := mcp.Request{
+		Params: mcp.CallToolParams{
+			Arguments: `{"lines": 3}`,
+		},
+	}
+
+	result, err := dtp.ExecuteGetLogs(ctx, req)
+	if err != nil {
+		t.Fatalf("ExecuteGetLogs failed: %v", err)
+	}
+
+	contentJSON := string(result.Content)
+
+	var contentList mcp.TextContentList
+	if err := twjson.Decode([]byte(contentJSON), &contentList); err != nil {
+		t.Fatalf("Failed to decode result content: %v. Content: %s", err, contentJSON)
+	}
+
+	if contentList.Len() != 1 {
+		t.Fatalf("Expected 1 content item, got %d", contentList.Len())
+	}
+
+	text := contentList[0].Text
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	if len(lines) != 3 {
+		t.Errorf("Expected 3 log lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[2], "Log line 5") {
+		t.Errorf("Last line should contain 'Log line 5', got '%s'", lines[2])
+	}
+}

--- a/test/logs_test.go
+++ b/test/logs_test.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tinywasm/app"
+)
+
+func TestLoggerNoFile(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "tinywasm_logs_test")
+	defer os.RemoveAll(tmpDir)
+
+	logger := app.NewLogger()
+	logger.SetRootDir(tmpDir)
+
+	logger.Logger("This should not be in a file")
+
+	logPath := filepath.Join(tmpDir, "logs.log")
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Errorf("logs.log should not exist")
+	}
+}
+
+func TestInternalError(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "tinywasm_internal_test")
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "logs.log")
+
+	// 1. debug=false
+	logger := app.NewLogger()
+	logger.SetRootDir(tmpDir)
+	logger.SetDebug(false)
+	logger.InternalError("Debug is false")
+
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Errorf("logs.log should not exist when debug is false")
+	}
+
+	// 2. debug=true
+	logger.SetDebug(true)
+	msg := "Debug is true"
+	logger.InternalError(msg)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(data), msg) {
+		t.Errorf("Log file should contain: %s", msg)
+	}
+}

--- a/test/sse_publisher_test.go
+++ b/test/sse_publisher_test.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tinywasm/app"
+)
+
+func TestSSEPublisherRecentLogs(t *testing.T) {
+	pub := app.NewSSEPublisher(nil) // No hub needed for ring buffer test
+
+	// Publish 150 entries
+	for i := 1; i <= 150; i++ {
+		pub.PublishTabLog("TAB", "HAND", "COL", fmt.Sprintf("msg %d", i))
+	}
+
+	logs := pub.RecentLogs()
+	if len(logs) != 100 {
+		t.Errorf("Expected 100 logs, got %d", len(logs))
+	}
+
+	// Should be logs from 51 to 150
+	if logs[0] != "msg 51" {
+		t.Errorf("First log should be 'msg 51', got '%s'", logs[0])
+	}
+	if logs[99] != "msg 150" {
+		t.Errorf("Last log should be 'msg 150', got '%s'", logs[99])
+	}
+}


### PR DESCRIPTION
This PR implements Stage 2 of the master plan.

Key changes:
1. **In-memory Logging**: Logs are now stored in an SSE-integrated ring buffer, eliminating the always-on `logs.log` file.
2. **MCP Tool Integration**: The `app_get_logs` tool now correctly retrieves from memory.
3. **MCP UI**: A new tab in the TUI shows MCP status.
4. **Improved Debugging**: Internal errors are handled separately and only written to disk if the `--debug` flag is provided. Standard output is used for critical early-stage failures to ensure they are visible.
5. **Redirection Layer**: The `Logger` struct now supports a redirection function, allowing it to bridge between generic components and the SSE/TUI stream.

Tests:
- `test/logs_test.go`: Verified file-writing behavior.
- `test/sse_publisher_test.go`: Verified ring buffer ordering and wrapping.
- `test/daemon_logs_test.go`: Verified MCP tool log retrieval.

---
*PR created automatically by Jules for task [15532452099889331234](https://jules.google.com/task/15532452099889331234) started by @cdvelop*